### PR TITLE
Migrate pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,10 @@
-[build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "apps"
 version = "0.2.1"
 description = "Django template package"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
+optional-dependencies = {front = ["npm"]}
 
 [options]
 include_package_data = true
@@ -15,3 +12,9 @@ zip_safe = false
 
 [tool.setuptools]
 packages = ["main", "apps"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "apps"
+version = "0.2.1"
+description = "Django template package"
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+
+[options]
+include_package_data = true
+zip_safe = false
+
+[tool.setuptools]
+packages = ["main", "apps"]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup
-
-setup(
-    name="apps",
-    version="0.2.0",
-    include_package_data=True,
-    packages=["apps.account", "apps.base"],
-    zip_safe=False,
-)


### PR DESCRIPTION
This proposal is in two parts:
 * Add pyproject.toml instead of legacy setup.py
 * Add optional dependency npm